### PR TITLE
refactor: Unify BytePlus API endpoint configuration (#9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
 # BytePlus API Configuration
 # Get your API key from: https://console.byteplus.com
 BYTEPLUS_API_KEY=your_byteplus_api_key_here
-BYTEPLUS_ENDPOINT=https://ark.ap-southeast.bytepluses.com/api/v3/images/generations
+
+# BytePlus API base endpoint (v3)
+# The client will append specific paths:
+# - /images/generations (Text-to-Image, Image-to-Image)
+# - /videos/generations (Image-to-Video)
+# - /chat/completions (Text generation for prompt optimization)
+BYTEPLUS_ENDPOINT=https://ark.ap-southeast.bytepluses.com/api/v3
 
 # GitHub Configuration (for Agent operations)
 GITHUB_TOKEN=your_github_personal_access_token_here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,8 +177,9 @@ ANTHROPIC_API_KEY=sk-ant-xxxxx
 # BytePlus API Key（必須 - Byteflow機能）
 BYTEPLUS_API_KEY=bp_xxxxx
 
-# BytePlus API Endpoint
-BYTEPLUS_ENDPOINT=https://api.byteplus.com/v1
+# BytePlus API Endpoint (v3 base URL)
+# Client appends paths: /images/generations, /videos/generations, /chat/completions
+BYTEPLUS_ENDPOINT=https://ark.ap-southeast.bytepluses.com/api/v3
 ```
 
 ## Byteflow開発ガイドライン

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Required environment variables:
 ```bash
 # BytePlus API (Required)
 BYTEPLUS_API_KEY=your_byteplus_api_key
-BYTEPLUS_ENDPOINT=https://ark.ap-southeast.bytepluses.com/api/v3/images/generations
+BYTEPLUS_ENDPOINT=https://ark.ap-southeast.bytepluses.com/api/v3
 
 # Anthropic API (Optional, for agents)
 ANTHROPIC_API_KEY=your_anthropic_api_key


### PR DESCRIPTION
## Summary
Unified BytePlus API endpoint configuration to support multiple API types with a single base URL.

## Changes
- Changed `BYTEPLUS_ENDPOINT` from specific path to base URL (`/api/v3`)
- Added documentation explaining endpoint structure
- Updated `.env.example`, `README.md`, and `CLAUDE.md`

## Technical Details
The BytePlus clients already correctly append specific paths:
- `/images/generations` - Text-to-Image, Image-to-Image generation
- `/videos/generations` - Image-to-Video generation  
- `/chat/completions` - Text generation for prompt optimization

**Before**:
```bash
BYTEPLUS_ENDPOINT=https://ark.ap-southeast.bytepluses.com/api/v3/images/generations
```

**After**:
```bash
BYTEPLUS_ENDPOINT=https://ark.ap-southeast.bytepluses.com/api/v3
```

## Benefits
✅ Single endpoint configuration for all API types
✅ Clear documentation of path structure
✅ Follows BytePlus API v3 architecture
✅ Reduces configuration complexity

## Testing
- [x] Verified client code correctly appends paths
- [x] Updated all documentation files
- [x] No breaking changes to existing code

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)