### PR TITLE
fix: Resolve React hydration mismatch error (#418)

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
 import { ThemeProvider } from "@/components/providers/theme-provider";
+import { HydrationBoundary } from "@/components/providers/hydration-boundary";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
 import { Toaster } from "@/components/ui/toaster";
@@ -39,10 +40,12 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <Header />
-          <main className="flex-1">{children}</main>
-          <Footer />
-          <Toaster />
+          <HydrationBoundary>
+            <Header />
+            <main className="flex-1">{children}</main>
+            <Footer />
+            <Toaster />
+          </HydrationBoundary>
         </ThemeProvider>
       </body>
     </html>

--- a/web/src/components/providers/hydration-boundary.tsx
+++ b/web/src/components/providers/hydration-boundary.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useGenerationStore } from '@/lib/store'
+
+/**
+ * Hydration Boundary
+ *
+ * Hydrates Zustand persist store on client-side only
+ * Prevents hydration mismatch errors with localStorage
+ */
+export function HydrationBoundary({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    // Rehydrate store from localStorage on client
+    useGenerationStore.persist.rehydrate()
+  }, [])
+
+  return <>{children}</>
+}

--- a/web/src/lib/store.ts
+++ b/web/src/lib/store.ts
@@ -152,6 +152,7 @@ export const useGenerationStore = create<GenerationStore>()(
       name: 'byteflow-storage',
       version: 1,
       storage: createJSONStorage(() => localStorage),
+      skipHydration: true, // Fix hydration mismatch - hydrate on client only
       partialize: (state) => ({
         history: state.history,
         favorites: state.favorites,


### PR DESCRIPTION
## Summary
Fixed React hydration mismatch error (#418) caused by Zustand persist middleware accessing localStorage during server-side rendering.

## Problem
```
Uncaught Error: Minified React error #418
```

This error occurred because the Zustand store was attempting to access `localStorage` during server-side rendering, causing a mismatch between server and client HTML.

## Solution

### 1. Skip Hydration in Persist Config
Added `skipHydration: true` to the Zustand persist configuration to prevent server-side localStorage access.

```typescript
// web/src/lib/store.ts
persist(
  (set, get) => ({ /* state */ }),
  {
    name: 'byteflow-storage',
    storage: createJSONStorage(() => localStorage),
    skipHydration: true, // Fix hydration mismatch
  }
)
```

### 2. Client-Side Rehydration
Created `HydrationBoundary` component to manually rehydrate the store on the client side only.

```typescript
// web/src/components/providers/hydration-boundary.tsx
'use client'

export function HydrationBoundary({ children }) {
  useEffect(() => {
    useGenerationStore.persist.rehydrate()
  }, [])
  return <>{children}</>
}
```

### 3. Updated Layout
Wrapped the app layout with `HydrationBoundary` to ensure proper client-side hydration.

## Testing
✅ Production build successful
✅ No hydration warnings in console
✅ LocalStorage persists correctly
✅ All pages render without errors

## Impact
- Eliminates React error #418
- Improves initial page load performance
- Maintains full localStorage functionality
- No breaking changes to existing features

🤖 Generated with [Claude Code](https://claude.com/claude-code)